### PR TITLE
fix: Always call `SetNextDirection` upon start

### DIFF
--- a/Assets/Audio.meta
+++ b/Assets/Audio.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: d193908bc07544fd99e2538f8ab78a05
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Editor/WaypointsControllerInspector.cs
+++ b/Assets/Scripts/Editor/WaypointsControllerInspector.cs
@@ -17,17 +17,11 @@ public class WaypointsControllerInspector : Editor
         if(GUILayout.Button("Set")) {
             Clear(controller);
             Set(controller);
-            SetNextDirection(controller);
             EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
         }
 
         if(GUILayout.Button("Clear")) {
             Clear(controller);
-            EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
-        }
-
-        if(GUILayout.Button("Set Next Direction")) {
-            SetNextDirection(controller);
             EditorSceneManager.MarkSceneDirty(EditorSceneManager.GetActiveScene());
         }
     }
@@ -91,22 +85,6 @@ public class WaypointsControllerInspector : Editor
             list.Add(c.gameObject);
         }
         list.ForEach(o => DestroyImmediate(o));
-    }
-
-    private void SetNextDirection(WaypointsController controller) {
-        List<Waypoint> waypoints = controller.GetComponentsInChildren<Waypoint>()
-                                   .Where(x => x.transform != controller.Prefab.transform)
-                                   .Where(x => x.transform != controller.transform)
-                                   .OrderBy(x => x.Index)
-                                   .ToList();
-        Waypoint lastWaypoint = null;
-        // Set next directions of index 0 to n-2
-        foreach(Waypoint nextWaypoint in waypoints) {
-            if(lastWaypoint != null) lastWaypoint.SetNextDirection(nextWaypoint.transform.position);
-            lastWaypoint = nextWaypoint;
-        }
-        // Set next direction of the last waypoint
-        if(lastWaypoint != null) lastWaypoint.SetNextDirection(waypoints[0].transform.position);
     }
 
     private Vector3 ProjectOnSide(Vector3 forward, Transform transform) {

--- a/Assets/Scripts/Waypoints/WaypointsController.cs
+++ b/Assets/Scripts/Waypoints/WaypointsController.cs
@@ -40,4 +40,26 @@ public class WaypointsController : MonoBehaviour
 
     [SerializeField] private float maxScale = 1.5f;
     public float MaxScale { get { return maxScale; } set { maxScale = value; } }
+    public void Start() {
+        SetNextDirections();
+    }
+
+    public void SetNextDirections() {
+        List<Waypoint> waypoints = GetComponentsInChildren<Waypoint>()
+                                   .Where(x => x.transform != Prefab.transform)
+                                   .Where(x => x.transform != transform)
+                                   .OrderBy(x => x.Index)
+                                   .ToList();
+        for (int i = 0; i < waypoints.Count; i++) {
+            waypoints[i].SetNextDirection(waypoints[(i + 1) % waypoints.Count].transform.position);
+        }
+    }
+
+    public Vector3 GetFirstNextDirection() {
+    return GetComponentsInChildren<Waypoint>()
+        .Where(x => x.transform != Prefab.transform)
+        .Where(x => x.transform != transform)
+        .OrderBy(x => x.Index)
+        .ToList().Last().NextDirection;
+}
 }

--- a/Assets/Scripts/Waypoints/WaypointsController.cs
+++ b/Assets/Scripts/Waypoints/WaypointsController.cs
@@ -55,11 +55,12 @@ public class WaypointsController : MonoBehaviour
         }
     }
 
-    public Vector3 GetFirstNextDirection() {
-    return GetComponentsInChildren<Waypoint>()
+    public Vector3 GetFirstNextDirection()
+    {
+        return GetComponentsInChildren<Waypoint>()
         .Where(x => x.transform != Prefab.transform)
         .Where(x => x.transform != transform)
         .OrderBy(x => x.Index)
         .ToList().Last().NextDirection;
-}
+    }
 }


### PR DESCRIPTION
Though specified in the README, people (including me) often forget to manually press the `Set Next Direction` button. It's better if we made it automatic.